### PR TITLE
FromJSRef instance for Maybe a

### DIFF
--- a/GHCJS/Marshal.hs
+++ b/GHCJS/Marshal.hs
@@ -112,7 +112,15 @@ instance FromJSRef Value where
                         v <- MaybeT (fromJSRef =<< getProp p' r)
                         return (fromJSString p', v)
                     return (Object (H.fromList propVals))
-                    
+
+instance FromJSRef a => FromJSRef (Maybe a) where
+  fromJSRef r = if eqRef r jsNull || eqRef r jsUndefined
+    then return $ Just Nothing
+    else do
+      mx <- fromJSRef $ castRef r
+      return $ case mx of
+        Just x  -> Just (Just x)
+        Nothing -> Nothing
 
 instance (FromJSRef a, FromJSRef b) => FromJSRef (a,b) where
    fromJSRef r = runMaybeT $ (,) <$> jf r 0 <*> jf r 1


### PR DESCRIPTION
This adds a `FromJSRef` instance for `Maybe a`, which deserializes `null`/`undefined` into `Nothing`, and otherwise tries to deserialize `x` into `Just x`. This mirrors the corresponding `ToJSRef` instance which serializes `Just x` into JS `x`, and `Nothing` into `null`. As a result, it will only fail (return `Nothing`) if the value is non-`null`, non-`undefined`, and also can't be read as an `a`.

I think adding `undefined` as a valid representation of `Nothing` is useful, first because the semantics of `null` and `undefined` in JS code somewhat overlap, and also so that `Maybe a` can represent e.g. a value in an object that may or may not have the value's key.
