### PR TITLE
Switch JSArray to use a type family

### DIFF
--- a/GHCJS/Foreign.hs
+++ b/GHCJS/Foreign.hs
@@ -251,16 +251,16 @@ foreign import javascript unsafe "$r = true"  js_true :: Int# -> Ref#
 foreign import javascript unsafe "$r = false" js_false :: Int# -> Ref#
 foreign import javascript unsafe "$r = null"  js_null :: Int# -> Ref#
 foreign import javascript unsafe "$r = undefined"  js_undefined :: Int# -> Ref#
-foreign import javascript unsafe "$r = []" js_emptyArray :: IO (JSArray a)
+foreign import javascript unsafe "$r = []" js_emptyArray :: IO (JSArray (JSRef a))
 foreign import javascript unsafe "$r = {}" js_emptyObj :: IO (JSRef a)
-foreign import javascript safe "$2.push($1)" js_push :: JSRef a -> JSArray a -> IO ()
-foreign import javascript safe "$1.length" js_length :: JSArray a -> IO Int
-foreign import javascript unsafe "$2.push($1)" js_unsafePush :: JSRef a -> JSArray a -> IO ()
-foreign import javascript unsafe "$1.length" js_unsafeLength :: JSArray a -> IO Int
-foreign import javascript safe "$2[$1]" js_index :: Int -> JSArray a -> IO (JSRef a)
+foreign import javascript safe "$2.push($1)" js_push :: JSRef a -> JSArray (JSRef a) -> IO ()
+foreign import javascript safe "$1.length" js_length :: JSArray (JSRef a) -> IO Int
+foreign import javascript unsafe "$2.push($1)" js_unsafePush :: JSRef a -> JSArray (JSRef a) -> IO ()
+foreign import javascript unsafe "$1.length" js_unsafeLength :: JSArray (JSRef a) -> IO Int
+foreign import javascript safe "$2[$1]" js_index :: Int -> JSArray (JSRef a) -> IO (JSRef a)
 foreign import javascript safe "$2[$1]" js_getProp :: JSString -> JSRef a -> IO (JSRef b)
 foreign import javascript safe "$3[$1] = $2" js_setProp :: JSString -> JSRef a -> JSRef b -> IO ()
-foreign import javascript unsafe "$2[$1]" js_unsafeIndex :: Int -> JSArray a -> IO (JSRef a)
+foreign import javascript unsafe "$2[$1]" js_unsafeIndex :: Int -> JSArray (JSRef a) -> IO (JSRef a)
 foreign import javascript unsafe "$2[$1]" js_unsafeGetProp :: JSString -> JSRef a -> IO (JSRef b)
 foreign import javascript unsafe "$3[$1] = $2" js_unsafeSetProp :: JSString -> JSRef a -> JSRef b -> IO ()
 foreign import javascript safe "h$listprops($1)" js_listProps :: JSRef a -> IO (JSArray JSString)
@@ -386,7 +386,7 @@ ptrToPtr' = unsafeCoerce
 ptr'ToPtr :: Ptr' a -> Ptr b
 ptr'ToPtr = unsafeCoerce
 
-toArray :: [JSRef a] -> IO (JSArray a)
+toArray :: [JSRef a] -> IO (JSArray (JSRef a))
 toArray xs = do
   a <- js_emptyArray
   let go ys = case ys of
@@ -396,11 +396,11 @@ toArray xs = do
   return a
 {-# INLINE toArray #-}
 
-pushArray :: JSRef b -> JSArray a -> IO ()
+pushArray :: JSRef b -> JSArray (JSRef a) -> IO ()
 pushArray r arr = js_push (castRef r) arr
 {-# INLINE pushArray #-}
 
-fromArray :: JSArray a -> IO [JSRef a]
+fromArray :: JSArray (JSRef a) -> IO [JSRef a]
 fromArray a = do
   l <- js_length a
   let go i | i < l     = (:) <$> js_index i a <*> go (i+1)
@@ -408,15 +408,15 @@ fromArray a = do
   go 0
 {-# INLINE fromArray #-}
 
-lengthArray :: JSArray a -> IO Int
+lengthArray :: JSArray (JSRef a) -> IO Int
 lengthArray a = js_length a
 {-# INLINE lengthArray #-}
 
-indexArray :: Int -> JSArray a -> IO (JSRef a)
+indexArray :: Int -> JSArray (JSRef a) -> IO (JSRef a)
 indexArray = js_index
 {-# INLINE indexArray #-}
 
-newArray :: IO (JSArray a)
+newArray :: IO (JSArray (JSRef a))
 newArray = js_emptyArray
 {-# INLINE newArray #-}
 
@@ -424,7 +424,7 @@ newObj :: IO (JSRef a)
 newObj = js_emptyObj
 {-# INLINE newObj #-}
 
-listProps :: JSRef a -> IO [JSRef JSString]
+listProps :: JSRef a -> IO [JSString]
 listProps o = fromArray =<< js_listProps o
 {-# INLINE listProps #-}
 

--- a/GHCJS/Types.hs
+++ b/GHCJS/Types.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE EmptyDataDecls, MagicHash, BangPatterns,
-    CPP, ForeignFunctionInterface, JavaScriptFFI #-}
+    CPP, ForeignFunctionInterface, JavaScriptFFI, TypeFamilies #-}
 
 module GHCJS.Types ( JSRef(..)
                    , isNull
@@ -38,7 +38,8 @@ type JSObject a = JSRef (JSObject_ a)
 type JSFun a    = JSRef (JSFun_ a)
 -- type JSObject'  = JSRef (JSObject (Any *))
 
-type JSArray a  = JSRef (JSArray_ a)
+type family JSArray a :: *
+type instance JSArray (JSRef a) = JSRef (JSArray_ a)
 
 #ifdef ghcjs_HOST_OS
 type Ref# = ByteArray#


### PR DESCRIPTION
Arrays will be `JSArray (JSRef a)` instead of `JSArray a`.
This means that the access phantom type `a` is not needed to make the
array type.

The existing code in that uses `JSArray JSString` is a bit simpler.
