### PR TITLE
Implement and test GHCJS.Buffer.{to,from}ByteString

### DIFF
--- a/GHCJS/Buffer.hs
+++ b/GHCJS/Buffer.hs
@@ -55,8 +55,6 @@ import           JavaScript.TypedArray.ArrayBuffer.Internal (SomeArrayBuffer)
 import           JavaScript.TypedArray.DataView.Internal    (SomeDataView)
 import qualified JavaScript.TypedArray.Internal as I
 
-import Foreign.ForeignPtr
-import Foreign.ForeignPtr.Unsafe
 import GHC.ForeignPtr
 
 create :: Int -> IO MutableBuffer

--- a/GHCJS/Buffer.hs
+++ b/GHCJS/Buffer.hs
@@ -57,7 +57,7 @@ import qualified JavaScript.TypedArray.Internal as I
 
 import Foreign.ForeignPtr
 import Foreign.ForeignPtr.Unsafe
-import System.IO.Unsafe
+import GHC.ForeignPtr
 
 create :: Int -> IO MutableBuffer
 create n | n >= 0    = js_create n
@@ -168,8 +168,8 @@ toByteString off (Just len) buf
 toByteString off Nothing buf   = unsafeToByteString off (byteLength buf - off) buf
 
 unsafeToByteString :: Int -> Int -> Buffer -> ByteString
-unsafeToByteString off len buf =
-  let fp = unsafePerformIO (newForeignPtr_ (unsafeToPtr buf))
+unsafeToByteString off len buf@(SomeBuffer bufRef) =
+  let fp = ForeignPtr (js_toAddr buf) (PlainPtr (js_toMutableByteArray bufRef))
   in BS.PS fp off len
 
 toPtr :: MutableBuffer -> Ptr a

--- a/ghcjs-base.cabal
+++ b/ghcjs-base.cabal
@@ -161,6 +161,7 @@ test-suite tests
     ghc-prim,
     ghcjs-prim,
     ghcjs-base,
+    primitive,
     quickcheck-unicode,
     random,
     test-framework >= 0.4,

--- a/test/Tests.hs
+++ b/test/Tests.hs
@@ -6,9 +6,10 @@ module Main
 
 import Test.Framework (defaultMain)
 
+import qualified Tests.Buffer as Buffer
 import qualified Tests.Properties as Properties
 import qualified Tests.Regressions as Regressions
 import qualified Tests.Marshal as Marshal
 
 main :: IO ()
-main = defaultMain [Properties.tests, Regressions.tests, Marshal.tests]
+main = defaultMain [Buffer.tests, Properties.tests, Regressions.tests, Marshal.tests]

--- a/test/Tests/Buffer.hs
+++ b/test/Tests/Buffer.hs
@@ -1,0 +1,80 @@
+module Tests.Buffer (
+  tests
+) where
+
+import Control.Exception (ErrorCall(..), catch)
+import Control.Monad (forM_)
+import Data.Primitive.ByteArray
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as BS8
+import Data.Word (Word8)
+import Test.Framework.Providers.HUnit (testCase)
+import Test.Framework.Providers.QuickCheck2 (testProperty)
+import Test.QuickCheck (Property, ioProperty, (==>))
+import Test.Framework (Test, testGroup)
+import Test.HUnit ((@=?), assertFailure)
+
+import GHCJS.Buffer
+
+byteLengthWorks :: Int -> Property
+byteLengthWorks i = (i >= 0) ==> (ioProperty $ do
+  buf <- create i
+  return (i == byteLength buf))
+
+fromByteStringNoOffset :: IO ()
+fromByteStringNoOffset = do
+  let bs = BS8.pack ['a'..'z']
+      (buf, offset, len) = fromByteString bs
+  0 @=? offset
+  26 @=? len
+  26 @=? byteLength buf
+  let ba = toByteArray buf
+  forM_ [0..25] $ \i -> do
+    BS.index bs i @=? indexByteArray ba i
+
+fromByteStringWithOffset :: IO ()
+fromByteStringWithOffset = do
+  let bs = BS8.pack ['a'..'z']
+      sliced = BS.take 10 . BS.drop 5 $ bs
+      (buf, offset, len) = fromByteString sliced
+  5 @=? offset
+  10 @=? len
+  26 @=? byteLength buf
+  let ba = toByteArray buf
+  forM_ [0..25] $ \i -> do
+    BS.index bs i @=? indexByteArray ba i
+
+atoz :: IO ByteArray
+atoz = do
+  ba <- newByteArray 26
+  forM_ [0..25] $ \i -> writeByteArray ba i (fromIntegral i + 65 :: Word8)
+  unsafeFreezeByteArray ba
+
+wrapIntoByteString :: IO ()
+wrapIntoByteString = do
+  buf <- fromByteArray `fmap` atoz
+  BS8.pack ['A'..'Z'] @=? toByteString 0 Nothing buf
+  BS8.pack ['K'..'Z'] @=? toByteString 10 Nothing buf
+  BS8.pack ['K'..'O'] @=? toByteString 10 (Just 5) buf
+
+toByteStringOffset :: IO ()
+toByteStringOffset = do
+  buf <- fromByteArray `fmap` atoz
+  tst (toByteString (-1) Nothing buf) "toByteString: negative offset"
+  tst (toByteString 100 Nothing buf) "toByteString: offset past end of buffer"
+  tst (toByteString 0 (Just (-1)) buf) "toByteString: negative length"
+  tst (toByteString 0 (Just (-1)) buf) "toByteString: negative length"
+  tst (toByteString 0 (Just 27) buf) "toByteString: length past end of buffer"
+  tst (toByteString 20 (Just 7) buf) "toByteString: length past end of buffer"
+  where tst expr expected = ign expr expected `catch` \(ErrorCall msg) -> expected @=? msg
+        ign expr expected = seq expr $ assertFailure ("Expected error " ++ show expected ++ " but got nothing")
+
+tests :: Test
+tests =
+  testGroup "Buffer" [
+    testProperty "byte length works" byteLengthWorks,
+    testCase "fromByteString - no offset" fromByteStringNoOffset,
+    testCase "fromByteString - offset" fromByteStringWithOffset,
+    testCase "toByteString" wrapIntoByteString,
+    testCase "toByteString - offset" toByteStringOffset
+    ]


### PR DESCRIPTION
Also exposes `create` and fixes a bug in `byteLength`.

I've pretty well convinced myself that the use of `unsafePerformIO` in
`toByteString` is safe if no one is playing mutate-the-immutable-Buffer
games.  I'm rather more unsatisfied with the `unsafeForeignPtrToPtr` ion
`fromByteString`.