### PR TITLE
Fix GHCJS.Foreign.Export

### DIFF
--- a/GHCJS/Foreign/Export.hs
+++ b/GHCJS/Foreign/Export.hs
@@ -84,7 +84,7 @@ foreign import javascript unsafe
   "h$exportValue"
   js_export :: Word64 -> Word64 -> Any -> IO (Export a)
 foreign import javascript unsafe
-  "h$derefExportedValue"
+  "h$derefExport"
   js_derefExport :: Word64 -> Word64 -> JSRef a -> IO (JSRef ())
 foreign import javascript unsafe
   "$r = $1;" js_toHeapObject :: JSRef a -> (# b #)

--- a/jsbits/export.js
+++ b/jsbits/export.js
@@ -1,11 +1,12 @@
 function h$exportValue(fp1a,fp1b,fp2a,fp2b,o) {
     var e = { fp1a: fp1a
             , fp1b: fp1b
-            , fp1c: fp1c
-            , fp1d: fp1d
+            , fp2a: fp2a
+            , fp2b: fp2b
             , root: o
-	    , _key: -1
+	        , _key: -1
             };
+    h$retain(e);
     return e;
 }
 


### PR DESCRIPTION
- the hs$export function had parameters fp2a fp2b but attempted to
  read fp1c and fp1d, which did not exist.
- Export.hs assumed deref was called hs$derefExportedValue but the
  actual function is hs$derefValue.
- A call to hs$retain was missing from the export.