### PR TITLE
add h$isBoolean to jsbits. Req'd by GHCJS.Foreign

### DIFF
--- a/jsbits/utils.js
+++ b/jsbits/utils.js
@@ -35,6 +35,10 @@ function h$isSymbol(o) {
     return typeof(o) === 'symbol';
 }
 
+function h$isBoolean(o) {
+    return typeof(o) === 'boolean';
+}
+
 function h$isFunction(o) {
     return typeof(o) === 'function';
 }


### PR DESCRIPTION
GHCJS.Foreign.Internal uses it but h$isBoolean doesn't appear to be defined anywhere.

This is a rebase of #28.