### PR TITLE
Added Float32/64 Typed array types

### DIFF
--- a/JavaScript/TypedArray.hs
+++ b/JavaScript/TypedArray.hs
@@ -2,7 +2,7 @@ module JavaScript.TypedArray
     ( TypedArray(..)
     , Int8Array, Int16Array, Int32Array
     , Uint8Array, Uint16Array, Uint32Array
-    , Uint8ClampedArray
+    , Uint8ClampedArray, Float32Array, Float64Array
     , length
     , byteLength
     , byteOffset


### PR DESCRIPTION
Seems like someone forgot to re-export Float32Array and  Float64Array in JavaScript.TypedArray from JavaScript.TypedArray.Internal.Types.
Also I would like to have (TypedArray a => JSRef -> a) interface for my WebGL things: some of the webGL methods return typed arrays of arbitrary type - https://developer.mozilla.org/en-US/docs/Web/API/ArrayBufferView