### PR TITLE
Fix Data.Text.Lazy support (h$lazyTextFromString)

### DIFF
--- a/jsbits/text.js
+++ b/jsbits/text.js
@@ -37,11 +37,12 @@ function h$textFromString(s) {
 
 function h$lazyTextToString(txt) {
     var s = '';
-    while(CONSTR_TAG(txt) === 2) {
-	var h = LAZY_TEXT_CHUNK_HEAD(txt);
-	s += h$textToString(TEXT_ARR(h), TEXT_OFF(h), TEXT_LEN(h));
-	txt = LAZY_TEXT_CHUNK_TAIL(txt);
+    while(LAZY_TEXT_IS_CHUNK(txt)) {
+        var head = LAZY_TEXT_CHUNK_HEAD(txt);
+        s  += h$textToString(DATA_TEXT_ARRAY(head), DATA_TEXT_OFFSET(head), DATA_TEXT_LENGTH(head));
+        txt = LAZY_TEXT_CHUNK_TAIL(txt);
     }
+    return s;
 }
 
 function h$safeTextFromString(x) {


### PR DESCRIPTION
This brings `Data.Text.Lazy` working.

`TEXT_ARR` macro was undefined (names changed). Requires also patching of `rts.h` that is in `ghcjs` repo (https://github.com/ghcjs/ghcjs/pull/431)