### PR TITLE
Fix typo in JavaScript.Web.MessageEvent.js_getData

### DIFF
--- a/JavaScript/Web/MessageEvent.hs
+++ b/JavaScript/Web/MessageEvent.hs
@@ -39,6 +39,5 @@ getData me = case js_getData me of
 
 foreign import javascript unsafe
   "$r2 = $1.data;\
-  \$r1 = typeof $r2 === 'string' ? 1 : ($r2 instanceof ArrayBuffer ? 2 : 3"
+  \$r1 = typeof $r2 === 'string' ? 1 : ($r2 instanceof ArrayBuffer ? 2 : 3)"
   js_getData :: MessageEvent -> (# Int#, JSVal #)
-


### PR DESCRIPTION
Otherwise the code does not compile:

```
Parse error in FFI pattern: $r2 = $1.data;$r1 = typeof $r2 === 'string' ? 1 : ($r2 instanceof ArrayBuffer ? 2 : 3
(line 1, column 86):
unexpected end of input
expecting digit, ".", value, "`(", "`", "(", "new", operator, "?" or ")"
```