### PR TITLE
Fix two typos for websockets

### DIFF
--- a/JavaScript/Web/MessageEvent.hs
+++ b/JavaScript/Web/MessageEvent.hs
@@ -39,5 +39,5 @@ getData me = case js_getData me of
 
 foreign import javascript unsafe
   "$r2 = $1.data;\
-  \$r1 = typeof $r2 === 'string' ? 1 : ($r2 instanceof ArrayBuffer ? 2 : 3)"
+  \$r1 = typeof $r2 === 'string' ? 1 : ($r2 instanceof ArrayBuffer ? 3 : 2)"
   js_getData :: MessageEvent -> (# Int#, JSVal #)

--- a/JavaScript/Web/WebSocket.hs
+++ b/JavaScript/Web/WebSocket.hs
@@ -175,7 +175,7 @@ foreign import javascript unsafe
 foreign import javascript unsafe
   "$1.url"                js_getUrl            :: WebSocket -> JSString
 foreign import javascript unsafe
-  "$1.binaryType === 'blob' ? 1 : 2"
+  "$1.binaryType === 'blob' ? 0 : 1"
   js_getBinaryType                             :: WebSocket -> IO Int
 foreign import javascript unsafe
   "$1.lastError"          js_getLastError      :: WebSocket -> IO JSVal


### PR DESCRIPTION
Hi,

I ran across two off by one bugs while trying to open a websocket connection for some code I was working on.

JavaScript/Web/MessageEvent.hs
-----------------------------------------
The conditional checking the type of the MessageEvent was returning inverted values for the two Binary types. See `getData` right above the change.

JavaScript/Web/WebSocket.hs
-----------------------------------------
Checking the binaryType property of a websocket object was returning a Int which is fed into a `toEnum` starting at value 1, instead of 0.

