### PR TITLE
Respect `.withCredentials`property of XHR

### DIFF
--- a/JavaScript/Web/XMLHttpRequest.hs
+++ b/JavaScript/Web/XMLHttpRequest.hs
@@ -137,7 +137,8 @@ xhr req = js_createXHR >>= \x ->
         forM_ (reqHeaders req) (\(n,v) -> js_setRequestHeader n v x)
         
         case reqWithCredentials req of
-          True -> js_setWithCredentials x
+          True  -> js_setWithCredentials x
+          False -> return ()
         
         r <- case reqData req of
           NoData                            ->

--- a/JavaScript/Web/XMLHttpRequest.hs
+++ b/JavaScript/Web/XMLHttpRequest.hs
@@ -138,7 +138,6 @@ xhr req = js_createXHR >>= \x ->
         
         case reqWithCredentials of
           True -> js_setWithCredentials x
-          False -> return ()
         
         r <- case reqData req of
           NoData                            ->

--- a/JavaScript/Web/XMLHttpRequest.hs
+++ b/JavaScript/Web/XMLHttpRequest.hs
@@ -136,7 +136,7 @@ xhr req = js_createXHR >>= \x ->
           (getResponseTypeString (Proxy :: Proxy a)) x
         forM_ (reqHeaders req) (\(n,v) -> js_setRequestHeader n v x)
         
-        case reqWithCredentials of
+        case reqWithCredentials req of
           True -> js_setWithCredentials x
         
         r <- case reqData req of

--- a/JavaScript/Web/XMLHttpRequest.hs
+++ b/JavaScript/Web/XMLHttpRequest.hs
@@ -135,6 +135,11 @@ xhr req = js_createXHR >>= \x ->
         js_setResponseType
           (getResponseTypeString (Proxy :: Proxy a)) x
         forM_ (reqHeaders req) (\(n,v) -> js_setRequestHeader n v x)
+        
+        case reqWithCredentials of
+          True -> js_setWithCredentials x
+          False -> return ()
+        
         r <- case reqData req of
           NoData                            ->
             js_send0 x
@@ -164,7 +169,7 @@ xhr req = js_createXHR >>= \x ->
                               (js_getAllResponseHeaders x)
                               (\h -> getResponseHeader' h x)
           1 -> throwIO XHRAborted
-          2 -> throwIO (XHRError "some error")
+          2 -> throwIO (XHRError "network request error")
   in doRequest `onException` js_abort x
 
 appendFormData :: JSString -> JSVal
@@ -193,6 +198,10 @@ xhrByteString = fmap
   (fmap (Buffer.toByteString 0 Nothing . Buffer.createFromArrayBuffer)) . xhr
 
 -- -----------------------------------------------------------------------------
+
+foreign import javascript unsafe
+  "$1.withCredentials = true;"
+  js_setWithCredentials :: XHR -> IO ()
 
 foreign import javascript unsafe
   "new XMLHttpRequest()"


### PR DESCRIPTION
`reqWithCredentials` field is present in the `Request` type, but it is not used for actual XHR requests. This way one can not make CORS requests with credentials, which results is a loss of interesting functionality for rich web applications which work with APIs from other origins.

This pull request makes `xhr` function respect `reqWithCredentials` parameter.

And also provides a little bit less mysterious error message on XHR errors ("some error" is very abstract :-)
