### PR TITLE
Change the WebSocket readyState to reflect the right values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *~
 *#
 /dist
+.stack-work/

--- a/JavaScript/Web/WebSocket.hs
+++ b/JavaScript/Web/WebSocket.hs
@@ -67,7 +67,7 @@ data WebSocketRequest = WebSocketRequest
 newtype WebSocket = WebSocket JSVal
 -- instance IsJSVal WebSocket
 
-data ReadyState = Closed | Connecting | Connected
+data ReadyState = Connecting | OPEN | CLOSING | CLOSED
   deriving (Data, Typeable, Enum, Eq, Ord, Show)
 
 data BinaryType = Blob | ArrayBuffer


### PR DESCRIPTION
I'm using the WebSocket API and find out that the readyState values doesn't reflect the right values. Maybe there's a reason? But I've made the change locally and it works great for my app. If this is a bug, hope this fix is merged.
