### PR TITLE
Added ability to explicitly cancel XHR requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *~
 *#
 /dist
+.stack-work

--- a/JavaScript/Web/XMLHttpRequest.hs
+++ b/JavaScript/Web/XMLHttpRequest.hs
@@ -5,9 +5,15 @@
              LambdaCase, MultiParamTypeClasses, DeriveGeneric #-}
 
 module JavaScript.Web.XMLHttpRequest ( xhr
+                                     , xhr'
                                      , xhrByteString
+                                     , xhrByteString'
                                      , xhrText
+                                     , xhrText'
                                      , xhrString
+                                     , xhrString'
+                                     , xhrCreate
+                                     , xhrAbort
                                      , Method(..)
                                      , Request(..)
                                      , RequestData(..)
@@ -57,7 +63,7 @@ data Method = GET | POST | PUT | DELETE
 
 data XHRError = XHRError String
               | XHRAborted
-              deriving (Generic, Data, Typeable, Show, Eq) 
+              deriving (Generic, Data, Typeable, Show, Eq)
 
 instance Exception XHRError
 
@@ -124,53 +130,59 @@ newtype XHR = XHR JSVal deriving (Typeable)
 -- -----------------------------------------------------------------------------
 -- main entry point
 
+doRequest :: forall a. ResponseType a => Request -> XHR -> IO (Response a)
+doRequest req x = do
+  case reqLogin req of
+    Nothing           ->
+      js_open2 (methodJSString (reqMethod req)) (reqURI req) x
+    Just (user, pass) ->
+      js_open4 (methodJSString (reqMethod req)) (reqURI req) user pass x
+  js_setResponseType
+    (getResponseTypeString (Proxy :: Proxy a)) x
+  forM_ (reqHeaders req) (\(n,v) -> js_setRequestHeader n v x)
+
+  case reqWithCredentials req of
+    True  -> js_setWithCredentials x
+    False -> return ()
+
+  r <- case reqData req of
+    NoData                            ->
+      js_send0 x
+    StringData str                    ->
+      js_send1 (pToJSVal str) x
+    TypedArrayData (SomeTypedArray t) ->
+      js_send1 t x
+    FormData xs                       -> do
+      fd@(JSFormData fd') <- js_createFormData
+      forM_ xs $ \(name, val) -> case val of
+        StringVal str               ->
+          js_appendFormData2 name (pToJSVal str) fd
+        BlobVal (SomeBlob b) mbFile ->
+          appendFormData name b mbFile fd
+        FileVal (SomeBlob b) mbFile ->
+          appendFormData name b mbFile fd
+      js_send1 fd' x
+  case r of
+    0 -> do
+      status <- js_getStatus x
+      r      <- do
+        hr <- js_hasResponse x
+        if hr then Just . wrapResponseType <$> js_getResponse x
+              else pure Nothing
+      return $ Response r
+                        status
+                        (js_getAllResponseHeaders x)
+                        (\h -> getResponseHeader' h x)
+    1 -> throwIO XHRAborted
+    2 -> throwIO (XHRError "network request error")
+
 xhr :: forall a. ResponseType a => Request -> IO (Response a)
-xhr req = js_createXHR >>= \x ->
-  let doRequest = do
-        case reqLogin req of
-          Nothing           ->
-            js_open2 (methodJSString (reqMethod req)) (reqURI req) x
-          Just (user, pass) ->
-            js_open4 (methodJSString (reqMethod req)) (reqURI req) user pass x
-        js_setResponseType
-          (getResponseTypeString (Proxy :: Proxy a)) x
-        forM_ (reqHeaders req) (\(n,v) -> js_setRequestHeader n v x)
-        
-        case reqWithCredentials req of
-          True  -> js_setWithCredentials x
-          False -> return ()
-        
-        r <- case reqData req of
-          NoData                            ->
-            js_send0 x
-          StringData str                    ->
-            js_send1 (pToJSVal str) x
-          TypedArrayData (SomeTypedArray t) ->
-            js_send1 t x
-          FormData xs                       -> do
-            fd@(JSFormData fd') <- js_createFormData
-            forM_ xs $ \(name, val) -> case val of
-              StringVal str               ->
-                js_appendFormData2 name (pToJSVal str) fd
-              BlobVal (SomeBlob b) mbFile ->
-                appendFormData name b mbFile fd
-              FileVal (SomeBlob b) mbFile ->
-                appendFormData name b mbFile fd
-            js_send1 fd' x
-        case r of
-          0 -> do
-            status <- js_getStatus x
-            r      <- do
-              hr <- js_hasResponse x
-              if hr then Just . wrapResponseType <$> js_getResponse x
-                    else pure Nothing
-            return $ Response r
-                              status
-                              (js_getAllResponseHeaders x)
-                              (\h -> getResponseHeader' h x)
-          1 -> throwIO XHRAborted
-          2 -> throwIO (XHRError "network request error")
-  in doRequest `onException` js_abort x
+xhr req = js_createXHR >>= \x -> doRequest req x `onException` js_abort x
+
+-- applications might need to abort xhr requests based on their business logic
+-- so we provide them a way to have xhr handle to cancel the xhr on demand
+xhr' :: forall a. ResponseType a => XHR -> Request -> IO (Response a)
+xhr' xo req = doRequest req xo `onException` js_abort xo
 
 appendFormData :: JSString -> JSVal
                -> Maybe JSString -> JSFormData -> IO ()
@@ -197,6 +209,19 @@ xhrByteString :: Request -> IO (Response ByteString)
 xhrByteString = fmap
   (fmap (Buffer.toByteString 0 Nothing . Buffer.createFromArrayBuffer)) . xhr
 
+xhrString' :: XHR -> Request -> IO (Response String)
+xhrString' xo = fmap (fmap JSS.unpack) . xhr' xo
+
+xhrText' :: XHR -> Request -> IO (Response Text)
+xhrText' xo = fmap (fmap textFromJSString) . xhr' xo
+
+xhrByteString' :: XHR -> Request -> IO (Response ByteString)
+xhrByteString' xo = fmap
+  (fmap (Buffer.toByteString 0 Nothing . Buffer.createFromArrayBuffer)) . xhr' xo
+
+  -- -----------------------------------------------------------------------------
+xhrCreate = js_createXHR
+xhrAbort  = js_abort
 -- -----------------------------------------------------------------------------
 
 foreign import javascript unsafe

--- a/JavaScript/Web/XMLHttpRequest.hs
+++ b/JavaScript/Web/XMLHttpRequest.hs
@@ -21,6 +21,7 @@ module JavaScript.Web.XMLHttpRequest ( xhr
                                      , ResponseType(..)
                                      , FormDataVal(..)
                                      , XHRError(..)
+                                     , XHR(..)
                                      ) where
 
 import Control.Applicative


### PR DESCRIPTION
Ability to cancel pending [XHR] requests from the business logic is important in real-world applications.

The most basic example is an autocomplete functionality. It continuously issues XHR requests while a user is typing a search term, aggregating input into some chunks. It might happen that a request issued earlier will arrive later than a request with a more recent input, overwriting displayed results. 

One could handle this by using some monotonic request ids, but this would complicate things a quite lot. 

Also, freeing unneeded resource is a good practice, especially important in a browser. Browsers have a limit on number of simultaneous connections to the same origin as low as 6. Should a user type fast, and should requests stall for a bit, connections limit would be exhausted, which would cause kind of denial-of-service by the browser, degrading user experience, interrupting other functionality etc.

So for business logic to be able to cancel requests it would need a request handle. This PR adds a family of `xhr*'` functions (`xhr'`, `xhrByteString'`, `xhrText'`, `xhrString'`) which take an XHR object handle as a parameter, and exports 2 existing functions for creating and aborting XHRs (`xhrCreate`, `xhrAbort`). 

So the low-level API looks like this:

```
do
  handle <- xhrCreate
  forkIO $ xhr’ handle …
  ...
  when condition $ xhrAbort handle
```

The API could be implemented in a more advanced way, but it is _low-level_ API after all :-)
