### PR TITLE
Removes redundancies & attoparsec dependency

### DIFF
--- a/GHCJS/Foreign/Internal.hs
+++ b/GHCJS/Foreign/Internal.hs
@@ -90,7 +90,7 @@ import           Control.Concurrent.MVar
 import           Control.DeepSeq (force)
 import           Control.Exception (evaluate, Exception)
 
-import           Foreign.ForeignPtr.Safe
+import           Foreign.ForeignPtr
 import           Foreign.Ptr
 
 import           Data.Primitive.Addr (Addr(..))

--- a/GHCJS/Marshal.hs
+++ b/GHCJS/Marshal.hs
@@ -1,7 +1,5 @@
-{-# LANGUAGE DefaultSignatures,
-             TypeOperators,
+{-# LANGUAGE TypeOperators,
              ScopedTypeVariables,
-             DefaultSignatures,
              FlexibleContexts,
              FlexibleInstances,
              OverloadedStrings,
@@ -10,8 +8,7 @@
              CPP,
              JavaScriptFFI,
              ForeignFunctionInterface,
-             UnliftedFFITypes,
-             BangPatterns
+             UnliftedFFITypes
   #-}
 
 module GHCJS.Marshal ( FromJSVal(..)
@@ -20,42 +17,25 @@ module GHCJS.Marshal ( FromJSVal(..)
                      , toJSVal_pure
                      ) where
 
-import           Control.Applicative
 import           Control.Monad
 import           Control.Monad.Trans.Maybe (MaybeT(..), runMaybeT)
 
 import qualified Data.Aeson as AE
-import           Data.Attoparsec.Number (Number(..))
-import           Data.Bits ((.&.))
-import           Data.Char (chr, ord)
 import qualified Data.HashMap.Strict as H
-import           Data.Int (Int8, Int16, Int32)
-import qualified Data.JSString as JSS
 import qualified Data.JSString.Text as JSS
-import           Data.Maybe
 import           Data.Scientific (Scientific, scientific, fromFloatDigits)
 import           Data.Text (Text)
 import qualified Data.Vector as V
-import           Data.Word (Word8, Word16, Word32, Word)
-import           Data.Primitive.ByteArray
-
-import           Unsafe.Coerce (unsafeCoerce)
 
 import           GHC.Int
 import           GHC.Word
-import           GHC.Types
-import           GHC.Float
-import           GHC.Prim
-import           GHC.Generics
 
 import           GHCJS.Types
 import           GHCJS.Foreign.Internal
 import           GHCJS.Marshal.Pure
 
 
-import qualified JavaScript.Array           as A
 import qualified JavaScript.Array.Internal  as AI
-import qualified JavaScript.Object          as O
 import qualified JavaScript.Object.Internal as OI
 
 import           GHCJS.Marshal.Internal
@@ -293,7 +273,7 @@ toJSVal_aeson x = cv (AE.toJSON x)
     convertValue :: AE.Value -> IO JSVal
     convertValue AE.Null       = return jsNull
     convertValue (AE.String t) = return (pToJSVal t)
-    convertValue (AE.Array a)  = (\(AI.SomeJSArray x) -> x) <$>
+    convertValue (AE.Array a)  = (\(AI.SomeJSArray x') -> x') <$>
                                  (AI.fromListIO =<< mapM convertValue (V.toList a))
     convertValue (AE.Number n) = toJSVal (realToFrac n :: Double)
     convertValue (AE.Bool b)   = return (toJSBool b)

--- a/JavaScript/Array.hs
+++ b/JavaScript/Array.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE ForeignFunctionInterface, JavaScriptFFI #-}
+{-# LANGUAGE JavaScriptFFI #-}
 module JavaScript.Array
     ( JSArray
     , MutableJSArray

--- a/JavaScript/JSON/Types/Generic.hs
+++ b/JavaScript/JSON/Types/Generic.hs
@@ -1,7 +1,7 @@
-{-# LANGUAGE CPP, DefaultSignatures, EmptyDataDecls, FlexibleInstances,
+{-# LANGUAGE CPP, EmptyDataDecls, FlexibleInstances,
     FunctionalDependencies, KindSignatures, OverlappingInstances,
     ScopedTypeVariables, TypeOperators, UndecidableInstances,
-    ViewPatterns, NamedFieldPuns, FlexibleContexts, PatternGuards,
+    NamedFieldPuns, FlexibleContexts, PatternGuards,
     RecordWildCards, DataKinds #-}
 
 -- |

--- a/JavaScript/JSON/Types/Instances.hs
+++ b/JavaScript/JSON/Types/Instances.hs
@@ -1,9 +1,7 @@
-{-# LANGUAGE CPP, DeriveDataTypeable, FlexibleContexts, FlexibleInstances,
-    GeneralizedNewtypeDeriving, IncoherentInstances, OverlappingInstances,
+{-# LANGUAGE CPP, FlexibleContexts, FlexibleInstances,
+    IncoherentInstances, OverlappingInstances,
     OverloadedStrings, UndecidableInstances, ViewPatterns #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
-
-{-# LANGUAGE DefaultSignatures #-}
 
 -- |
 -- Module:      Data.Aeson.Types.Instances

--- a/JavaScript/JSON/Types/Instances.hs
+++ b/JavaScript/JSON/Types/Instances.hs
@@ -66,20 +66,24 @@ import qualified JavaScript.JSON.Types.Internal as I
 
 import Data.Scientific (Scientific)
 import qualified Data.Scientific as Scientific (coefficient, base10Exponent, fromFloatDigits, toRealFloat)
-import Data.Attoparsec.Number (Number(..))
 import Data.Fixed
 import Data.Hashable (Hashable(..))
 import Data.Int (Int8, Int16, Int32, Int64)
 import Data.Maybe (fromMaybe)
 import Data.Monoid (Dual(..), First(..), Last(..), mappend)
 import Data.Ratio (Ratio, (%), numerator, denominator)
-import Data.Text (Text, pack, unpack)
+import Data.Text (Text)
 import Data.Time (UTCTime, ZonedTime(..), TimeZone(..))
-import Data.Time.Format (FormatTime, formatTime, parseTimeM, defaultTimeLocale, dateTimeFmt)
+import Data.Time.Format (FormatTime, formatTime, parseTimeM)
 import Data.Traversable (traverse)
 import Data.Vector (Vector)
 import Data.Word (Word, Word8, Word16, Word32, Word64)
 import Foreign.Storable (Storable)
+-- #if MIN_VERSION_time(1,5,0)
+import Data.Time.Format(defaultTimeLocale, dateTimeFmt)
+-- #else
+-- import System.Locale (defaultTimeLocale, dateTimeFmt)
+-- #endif
 import Unsafe.Coerce
 
 import qualified Data.HashMap.Strict as H
@@ -480,11 +484,14 @@ instance ToJSON DotNetTime where
       where secs  = formatTime defaultTimeLocale "/Date(%s" t
     {-# INLINE toJSON #-}
 
+
+parseTime = parseTimeM True
+
 instance FromJSON DotNetTime where
     parseJSON = withJSString "DotNetTime" $ \t ->
         let (s,m) = JSS.splitAt (JSS.length t - 5) t
             t'    = JSS.concat [s,".",m]
-        in case parseTimeM True defaultTimeLocale "/Date(%s%Q)/" (JSS.unpack t') of
+        in case parseTime defaultTimeLocale "/Date(%s%Q)/" (JSS.unpack t') of
              Just d -> pure (DotNetTime d)
              _      -> fail "could not parse .NET time"
     {-# INLINE parseJSON #-}
@@ -506,7 +513,7 @@ instance FromJSON ZonedTime where
       <|> fail "could not parse ECMA-262 ISO-8601 date"
       where
         tryFormat f =
-          case parseTimeM True defaultTimeLocale f (JSS.unpack t) of
+          case parseTime defaultTimeLocale f (JSS.unpack t) of
             Just d -> pure d
             Nothing -> empty
         tryFormats = foldr1 (<|>) . map tryFormat
@@ -529,7 +536,7 @@ instance ToJSON UTCTime where
 
 instance FromJSON UTCTime where
     parseJSON = withJSString "UTCTime" $ \t ->
-        case parseTimeM True defaultTimeLocale "%FT%T%QZ" (JSS.unpack t) of
+        case parseTime defaultTimeLocale "%FT%T%QZ" (JSS.unpack t) of
           Just d -> pure d
           _      -> fail "could not parse ISO-8601 date"
     {-# INLINE parseJSON #-}
@@ -1050,27 +1057,6 @@ typeMismatch expected actual =
              Number _ -> "Number"
              Bool _   -> "Boolean"
              Null     -> "Null"
-
-realFloatToJSON :: RealFloat a => a -> Value
-realFloatToJSON d
-    | isNaN d || isInfinite d = nullValue
-    | otherwise               = doubleValue (realToFrac d)
-{-# INLINE realFloatToJSON #-}
-
-scientificToNumber :: Scientific -> Number
-scientificToNumber s
-    | e < 0     = D $ Scientific.toRealFloat s
-    | otherwise = I $ c * 10 ^ e
-  where
-    e = Scientific.base10Exponent s
-    c = Scientific.coefficient s
-{-# INLINE scientificToNumber #-}
-
-parseRealFloat :: RealFloat a => String -> Value -> Parser a
-parseRealFloat _        (match -> Number d) = pure $ realToFrac d
-parseRealFloat _        (match -> Null)     = pure (0/0)
-parseRealFloat expected v                   = typeMismatch expected v
-{-# INLINE parseRealFloat #-}
 
 parseIntegral :: Integral a => String -> Value -> Parser a
 parseIntegral expected = withDouble expected $ pure . floor

--- a/JavaScript/JSON/Types/Internal.hs
+++ b/JavaScript/JSON/Types/Internal.hs
@@ -8,7 +8,6 @@ module JavaScript.JSON.Types.Internal
     ( -- * Core JSON types
       SomeValue(..),  Value,  MutableValue
     , SomeValue'(..), Value', MutableValue'
-    , MutableValue, MutableValue'
     , emptyArray, isEmptyArray
     , Pair
     , Object, MutableObject

--- a/ghcjs-base.cabal
+++ b/ghcjs-base.cabal
@@ -136,7 +136,6 @@ library
                    time                 >= 1.5  && < 1.7,
                    hashable             >= 1.2  && < 1.3,
                    unordered-containers >= 0.2  && < 0.3,
-                   attoparsec           >= 0.11 && < 0.14,
                    transformers         >= 0.3  && < 0.6,
                    primitive            >= 0.5  && < 0.7,
                    deepseq              >= 1.3  && < 1.5,


### PR DESCRIPTION
While exploring #79 I found that much of the code in `Javascript/JSON/Types/Instances` was not used.
This revealed that the Attoparsec's `Number` was unused.

The rest of the PR includes removal of redundant pragmas, imports and functions.
