### PR TITLE
export `getJSVal` from `Data.JSString`

### DIFF
--- a/Data/JSString.hs
+++ b/Data/JSString.hs
@@ -138,6 +138,9 @@ module Data.JSString ( JSString
                        -- * Zipping
                      , zip
                      , zipWith
+                     
+                       -- * Coercion
+                       getJSVal
                      ) where
 
 import           Prelude


### PR DESCRIPTION
Since `JSString` is just a newtype wrapper, and because JS is unityped, `getJSVal` should always be safe (or at least no *less* safe than the way it was generated in the first place). Furthermore, being able to treat a `JSString` as a `JSVal` is often important in FFI code, as many JS functions can accept multiple "types" of values.

The alternative is to use `unsafeCoerce` which is not super great. Also the function is defined but not used anywhere here or exported, so why not export it.

Apologies if this has already been brought up and decided against.