### PR TITLE
Removed unused Data.Primitive.Addr import (deprecated in primitive-0.7.0.0)

### DIFF
--- a/GHCJS/Foreign/Internal.hs
+++ b/GHCJS/Foreign/Internal.hs
@@ -93,7 +93,6 @@ import           Control.Exception (evaluate, Exception)
 import           Foreign.ForeignPtr.Safe
 import           Foreign.Ptr
 
-import           Data.Primitive.Addr (Addr(..))
 import           Data.Primitive.ByteArray
 import           Data.Typeable (Typeable)
 


### PR DESCRIPTION
Data.Primitive.Addr is deprecated in primitive-0.7.0.0
and the import is unused