### PR TITLE
Update aeson, attoparsec, dlist bounds

### DIFF
--- a/ghcjs-base.cabal
+++ b/ghcjs-base.cabal
@@ -129,18 +129,18 @@ library
                    binary               >= 0.8  && < 0.11,
                    bytestring           >= 0.10 && < 0.11,
                    text                 >= 1.1  && < 1.3,
-                   aeson                >= 0.8  && < 1.5,
+                   aeson                >= 0.8  && < 1.6,
                    scientific           >= 0.3  && < 0.4,
                    vector               >= 0.10 && < 0.13,
                    containers           >= 0.5  && < 0.7,
                    time                 >= 1.5  && < 1.10,
                    hashable             >= 1.2  && < 1.4,
                    unordered-containers >= 0.2  && < 0.3,
-                   attoparsec           >= 0.11 && < 0.14,
+                   attoparsec           >= 0.11 && < 0.15,
                    transformers         >= 0.3  && < 0.6,
                    primitive            >= 0.5  && < 0.8,
                    deepseq              >= 1.3  && < 1.5,
-                   dlist                >= 0.7  && < 0.9
+                   dlist                >= 0.7  && < 1.1
 
 test-suite tests
   type:           exitcode-stdio-1.0


### PR DESCRIPTION
It builds with `ghcjs-8.6` and tests almost pass, except e.g.

```
  [Char]:
    pure_to_from_jsval: [Failed]
*** Failed! Falsified (after 6 tests and 3 shrinks):
"\138423"
```

i.e. when `Char`s generated by recent `QuickCheck` are out out of BMP (don't fit into 16bit).

I think these failures are not related to this PR.