### PR TITLE
Remove old GHCJS support

### DIFF
--- a/JavaScript/Web/AnimationFrame.hs
+++ b/JavaScript/Web/AnimationFrame.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE JavaScriptFFI #-}
 {-# LANGUAGE InterruptibleFFI #-}
 {-# LANGUAGE DeriveDataTypeable #-}
-{-# LANGUAGE CPP #-}
 
 {- |
      Animation frames are the browser's mechanism for smooth animation.
@@ -65,11 +64,7 @@ cancelAnimationFrame h = js_cancelAnimationFrame h
 
 foreign import javascript unsafe "(() => { return { handle: null, callback: null }; })"
   js_makeAnimationFrameHandle :: IO AnimationFrameHandle
-#ifdef __GHCJS__
-foreign import javascript unsafe "(() => { return { handle: null, callback: $1 }; })"
-#else
 foreign import javascript unsafe "(($1) => { return { handle: null, callback: $1 }; })"
-#endif
   js_makeAnimationFrameHandleCallback :: JSVal -> IO AnimationFrameHandle
 foreign import javascript unsafe "h$animationFrameCancel"
   js_cancelAnimationFrame :: AnimationFrameHandle -> IO ()

--- a/ghcjs-base.cabal
+++ b/ghcjs-base.cabal
@@ -134,7 +134,7 @@ library
                    scientific           >= 0.3.7 && < 0.4,
                    vector               >= 0.10 && < 0.14,
                    containers           >= 0.5  && < 0.8,
-                   time                 >= 1.5  && < 1.13,
+                   time                 >= 1.5  && < 1.15,
                    hashable             >= 1.2  && < 1.5,
                    unordered-containers >= 0.2  && < 0.3,
                    attoparsec           >= 0.11 && < 0.15,


### PR DESCRIPTION
PR #137 included #ifdef __GHCJS__ for the old GHCJS.

ghcjs-base >= 0.8 is for the new GHC JS backend only.

If we need to update support for the old GHCJS version in the future we will need to create a branch from the 0.2.0.3 tag.