### PR TITLE
Locally scope buffers

### DIFF
--- a/jsbits/text.js
+++ b/jsbits/text.js
@@ -15,8 +15,8 @@ function h$textToString(arr, off, len) {
  */
 function h$textFromString(s) {
     var encoder = new TextEncoder("utf-8");
-    u8 = encoder.encode(s);
-    b = h$wrapBuffer(u8.buffer, true, u8.byteOffset, u8.byteLength);
+    var u8 = encoder.encode(s);
+    var b = h$wrapBuffer(u8.buffer, true, u8.byteOffset, u8.byteLength);
     RETURN_UBX_TUP2(b, u8.byteLength);
 }
 


### PR DESCRIPTION
By default, omitting `var` introduces variables into the global scope. When combined with "use strict" JS runtimes will insist the variable is undefined.

This PR locally scopes the text buffers to pass "use strict"