### PR TITLE
Drop `window` from `requestAnimationFrame`

### DIFF
--- a/JavaScript/Web/AnimationFrame.hs
+++ b/JavaScript/Web/AnimationFrame.hs
@@ -69,7 +69,7 @@ foreign import javascript unsafe "(($1) => { return { handle: null, callback: $1
 foreign import javascript unsafe "h$animationFrameCancel"
   js_cancelAnimationFrame :: AnimationFrameHandle -> IO ()
 foreign import javascript interruptible
-  "((x,c) => { return x.handle = window.requestAnimationFrame(c); })"
+  "((x,c) => { return x.handle = requestAnimationFrame(c); })"
   js_waitForAnimationFrame :: AnimationFrameHandle -> IO Double
 foreign import javascript unsafe "h$animationFrameRequest"
   js_requestAnimationFrame :: AnimationFrameHandle -> IO ()

--- a/jsbits/animationFrame.js
+++ b/jsbits/animationFrame.js
@@ -1,6 +1,6 @@
 //#OPTIONS: CPP
 function h$animationFrameCancel(h) {
-    if(h.handle) window.cancelAnimationFrame(h.handle);
+    if(h.handle) cancelAnimationFrame(h.handle);
     if(h.callback) {
         h$release(h.callback)
         h.callback = null;
@@ -8,7 +8,7 @@ function h$animationFrameCancel(h) {
 }
 
 function h$animationFrameRequest(h) {
-    h.handle = window.requestAnimationFrame(function(ts) {
+    h.handle = requestAnimationFrame(function(ts) {
         var cb = h.callback;
         if(cb) {
 	        h$release(cb);


### PR DESCRIPTION
This drops the `window.` prefix from `requestAnimationFrame` usage. Not all JS environments support `window`, but `requestAnimationFrame` is now generally available via the global scope.